### PR TITLE
Fix building with recent nixpkgs

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -79,11 +79,7 @@ overrideHaskellPackages oc packages = vcat
   , nest 2 $ vcat
     [ attr "ghc" ("pkgs.haskell.compiler." <> toNixGhcVersion (oc ^. ocGhc))
     , attr "compilerConfig" "self: extends pkgOverrides (extends stackageConfig (stackagePackages self))"
-    , "haskellLib = import (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {"
-    , nest 2 "inherit pkgs;"
-    , nest 2 "inherit (pkgs) lib;"
-    , "};"
-    , "inherit (stdenv) lib;"
+    , attr "haskellLib" "callPackage (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {}"
     ]
   , "}"
   ]

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -59,8 +59,9 @@ overrideHaskellPackages oc packages = vcat
   [ funargs ["nixpkgs ? import <nixpkgs> {}"]
   , ""
   , "with nixpkgs;"
-  , "let"
+  , "let nixpkgsPath = <nixpkgs>;"
   , nest 2 "inherit (stdenv.lib) extends;"
+  , nest 2 ""
   , nest 2 $ vcat
     [ attr "stackagePackages" . importStackagePackages $ oc ^. ocStackagePackages
     , attr "stackageConfig" . callStackageConfig $ oc ^. ocStackageConfig ]
@@ -74,10 +75,15 @@ overrideHaskellPackages oc packages = vcat
     , "};"
     , ""
     ]
-  , "in callPackage <nixpkgs/pkgs/development/haskell-modules> {"
+  , "in callPackage (nixpkgsPath + \"/pkgs/development/haskell-modules\") {"
   , nest 2 $ vcat
     [ attr "ghc" ("pkgs.haskell.compiler." <> toNixGhcVersion (oc ^. ocGhc))
     , attr "compilerConfig" "self: extends pkgOverrides (extends stackageConfig (stackagePackages self))"
+    , "haskellLib = import (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {"
+    , nest 2 "inherit pkgs;"
+    , nest 2 "inherit (pkgs) lib;"
+    , "};"
+    , "inherit (stdenv) lib;"
     ]
   , "}"
   ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,6 @@ packages:
 extra-deps:
 - distribution-nixpkgs-1.1
 - hopenssl-2.2
+nix:
+  packages: [icu openssl zlib]
+


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/commit/74f5fe50681003f075bf0b1ff811d0c0cd7c64f3 - now need to provide `lib` and `haskellLib` arguments to `haskell-modules`.

Based atop https://github.com/4e6/stack2nix/pull/7, but can rebase if you prefer not to merge that.

