### PR TITLE
Support overriding the `nixpkgs` to use.

### DIFF
--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -79,11 +79,7 @@ overrideHaskellPackages oc packages = vcat
   , nest 2 $ vcat
     [ attr "ghc" ("pkgs.haskell.compiler." <> toNixGhcVersion (oc ^. ocGhc))
     , attr "compilerConfig" "self: extends pkgOverrides (extends stackageConfig (stackagePackages self))"
-    , "haskellLib = import (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {"
-    , nest 2 "inherit pkgs;"
-    , nest 2 "inherit (pkgs) lib;"
-    , "};"
-    , "inherit (stdenv) lib;"
+    , attr "haskellLib" "callPackage (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {}"
     ]
   , "}"
   ]

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -59,8 +59,9 @@ overrideHaskellPackages oc packages = vcat
   [ funargs ["nixpkgs ? import <nixpkgs> {}"]
   , ""
   , "with nixpkgs;"
-  , "let"
+  , "let nixpkgsPath = <nixpkgs>;"
   , nest 2 "inherit (stdenv.lib) extends;"
+  , nest 2 ""
   , nest 2 $ vcat
     [ attr "stackagePackages" . importStackagePackages $ oc ^. ocStackagePackages
     , attr "stackageConfig" . callStackageConfig $ oc ^. ocStackageConfig ]
@@ -74,10 +75,15 @@ overrideHaskellPackages oc packages = vcat
     , "};"
     , ""
     ]
-  , "in callPackage <nixpkgs/pkgs/development/haskell-modules> {"
+  , "in callPackage (nixpkgsPath + \"/pkgs/development/haskell-modules\") {"
   , nest 2 $ vcat
     [ attr "ghc" ("pkgs.haskell.compiler." <> toNixGhcVersion (oc ^. ocGhc))
     , attr "compilerConfig" "self: extends pkgOverrides (extends stackageConfig (stackagePackages self))"
+    , "haskellLib = import (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {"
+    , nest 2 "inherit pkgs;"
+    , nest 2 "inherit (pkgs) lib;"
+    , "};"
+    , "inherit (stdenv) lib;"
     ]
   , "}"
   ]

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -20,7 +20,9 @@ import           Language.Nix.PrettyPrinting as PP
 data OverrideConfig = OverrideConfig
   { _ocGhc              :: !Version
   , _ocStackagePackages :: !FilePath
-  , _ocStackageConfig   :: !FilePath }
+  , _ocStackageConfig   :: !FilePath
+  , _ocNixpkgs          :: !FilePath
+  }
 
 makeLenses ''OverrideConfig
 
@@ -49,10 +51,15 @@ callStackageConfig path = hsep
 
 overrideHaskellPackages :: OverrideConfig -> NonEmpty Derivation -> Doc
 overrideHaskellPackages oc packages = vcat
-  [ funargs ["nixpkgs ? import <nixpkgs> {}"]
+  [ funargs ["nixpkgs ? import "
+            <> disp (fromString (oc ^. ocNixpkgs) :: Nix.FilePath)
+            <> " {}"
+            ]
   , ""
   , "with nixpkgs;"
-  , "let nixpkgsPath = <nixpkgs>;"
+  , nest 2 $ "let nixpkgsPath = "
+          <> disp (fromString (oc ^. ocNixpkgs) :: Nix.FilePath)
+          <> ";"
   , nest 2 "inherit (stdenv.lib) extends;"
   , nest 2 ""
   , nest 2 $ vcat

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -57,11 +57,8 @@ overrideHaskellPackages oc packages = vcat
             ]
   , ""
   , "with nixpkgs;"
-  , nest 2 $ "let nixpkgsPath = "
-          <> disp (fromString (oc ^. ocNixpkgs) :: Nix.FilePath)
-          <> ";"
+  , "let"
   , nest 2 "inherit (stdenv.lib) extends;"
-  , nest 2 ""
   , nest 2 $ vcat
     [ attr "stackagePackages" . importStackagePackages $ oc ^. ocStackagePackages
     , attr "stackageConfig" . callStackageConfig $ oc ^. ocStackageConfig ]
@@ -75,11 +72,11 @@ overrideHaskellPackages oc packages = vcat
     , "};"
     , ""
     ]
-  , "in callPackage (nixpkgsPath + \"/pkgs/development/haskell-modules\") {"
+  , "in callPackage (nixpkgs.path + \"/pkgs/development/haskell-modules\") {"
   , nest 2 $ vcat
     [ attr "ghc" ("pkgs.haskell.compiler." <> toNixGhcVersion (oc ^. ocGhc))
     , attr "compilerConfig" "self: extends pkgOverrides (extends stackageConfig (stackagePackages self))"
-    , attr "haskellLib" "callPackage (nixpkgsPath + \"/pkgs/development/haskell-modules/lib.nix\") {}"
+    , attr "haskellLib" "callPackage (nixpkgs.path + \"/pkgs/development/haskell-modules/lib.nix\") {}"
     ]
   , "}"
   ]

--- a/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
+++ b/src/Distribution/Nixpkgs/Haskell/Stack/PrettyPrinting.hs
@@ -43,13 +43,6 @@ importStackagePackages path = hsep
   , "}"
   ]
 
-importStackageConfig :: FilePath -> Doc
-importStackageConfig path = hsep
-  [ "import", disp (fromString path :: Nix.FilePath), "{"
-  , "inherit pkgs;"
-  , "}"
-  ]
-
 callStackageConfig :: FilePath -> Doc
 callStackageConfig path = hsep
   [ "callPackage", disp (fromString path :: Nix.FilePath), "{}"]

--- a/src/Language/Nix/FilePath.hs
+++ b/src/Language/Nix/FilePath.hs
@@ -43,4 +43,7 @@ parseFilePath = do
     else pfail
 
 renderFilePath :: FilePath -> String
-renderFilePath = Posix.combine "." . Posix.normalise . unFilePath
+renderFilePath = Posix.combine "."
+               . Posix.normalise
+               . Posix.dropTrailingPathSeparator
+               . unFilePath

--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -78,7 +78,9 @@ mkOverrideConfig :: Options -> Version -> OverrideConfig
 mkOverrideConfig opts ghcVersion = OverrideConfig
   { _ocGhc              = ghcVersion
   , _ocStackagePackages = opts ^. optOutStackagePackages
-  , _ocStackageConfig   = opts ^. optOutStackageConfig }
+  , _ocStackageConfig   = opts ^. optOutStackageConfig
+  , _ocNixpkgs          = opts ^. optNixpkgsRepository
+  }
 
 mkS2nOptions :: StackConfig -> Options -> S2n.Options
 mkS2nOptions conf opts = S2n.Options


### PR DESCRIPTION
This argument was present before, but was not respected.